### PR TITLE
Fix issues with PHP 7.4

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3475,7 +3475,7 @@ class Calculation
 
                     //    If the last entry on the stack was a : operator, then we have a cell range reference
                     $testPrevOp = $stack->last(1);
-                    if ($testPrevOp['value'] == ':') {
+                    if ($testPrevOp !== null && $testPrevOp['value'] === ':') {
                         //    If we have a worksheet reference, then we're playing with a 3D reference
                         if ($matches[2] == '') {
                             //    Otherwise, we 'inherit' the worksheet reference from the start cell reference
@@ -3494,7 +3494,7 @@ class Calculation
                 } else {    // it's a variable, constant, string, number or boolean
                     //    If the last entry on the stack was a : operator, then we may have a row or column range reference
                     $testPrevOp = $stack->last(1);
-                    if ($testPrevOp['value'] == ':') {
+                    if ($testPrevOp !== null && $testPrevOp['value'] === ':') {
                         $startRowColRef = $output[count($output) - 1]['value'];
                         list($rangeWS1, $startRowColRef) = Worksheet::extractSheetTitle($startRowColRef, true);
                         if ($rangeWS1 != '') {

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -51,16 +51,16 @@ class DefaultValueBinder implements IValueBinder
         // Match the value against a few data types
         if ($pValue === null) {
             return DataType::TYPE_NULL;
+        } elseif (is_float($pValue) || is_int($pValue)) {
+            return DataType::TYPE_NUMERIC;
+        } elseif (is_bool($pValue)) {
+            return DataType::TYPE_BOOL;
         } elseif ($pValue === '') {
             return DataType::TYPE_STRING;
         } elseif ($pValue instanceof RichText) {
             return DataType::TYPE_INLINE;
         } elseif (is_string($pValue) && $pValue[0] === '=' && strlen($pValue) > 1) {
             return DataType::TYPE_FORMULA;
-        } elseif (is_bool($pValue)) {
-            return DataType::TYPE_BOOL;
-        } elseif (is_float($pValue) || is_int($pValue)) {
-            return DataType::TYPE_NUMERIC;
         } elseif (preg_match('/^[\+\-]?(\d+\\.?\d*|\d*\\.?\d+)([Ee][\-\+]?[0-2]?\d{1,3})?$/', $pValue)) {
             $tValue = ltrim($pValue, '+-');
             if (is_string($pValue) && $tValue[0] === '0' && strlen($tValue) > 1 && $tValue[1] !== '.') {

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1105,7 +1105,7 @@ class Worksheet extends WriterPart
                     break;
                 case 'f':            // Formula
                     $attributes = $pCell->getFormulaAttributes();
-                    if ($attributes['t'] === 'array') {
+                    if ($attributes !== null && $attributes['t'] === 'array') {
                         $objWriter->startElement('f');
                         $objWriter->writeAttribute('t', 'array');
                         $objWriter->writeAttribute('ref', $pCellAddress);


### PR DESCRIPTION
This is a bugfix

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

- Expected array being `null` means that accessing the index crashes in PHP 7.4 and corrupts the output file
- Improve default binder